### PR TITLE
chore: update and adhere to lint settings

### DIFF
--- a/environment/.eslintrc
+++ b/environment/.eslintrc
@@ -24,10 +24,10 @@
     "strict": [2, "global"],
 
     // Code style
-    "indent": [2, 4],
+    "indent": [2, 2],
     "quotes": [2, "single"],
-    "semi": ["error", "always"],
-    "space-before-function-paren": ["error", "always"],
+    "semi": ["warn", "never"],
+    "space-before-function-paren": 0,
     "no-use-before-define": 0,
     "no-unused-expressions": "off",
     "eqeqeq": [2, "smart"],
@@ -38,7 +38,7 @@
     "comma-spacing": [2, {"before": false, "after": true}],
     "camelcase": "off",
     "no-mixed-spaces-and-tabs": [2, "smart-tabs"],
-    "comma-dangle": [1, "always-multiline"],
+    "comma-dangle": [1, "only-multiline"],
     "no-dupe-args": 2,
     "no-dupe-keys": 2,
     "no-debugger": 0,

--- a/environment/commands/danger-submit-invalid-near-block.js
+++ b/environment/commands/danger-submit-invalid-near-block.js
@@ -1,4 +1,3 @@
-const ProcessManager = require('pm2')
 const { Near2EthRelay } = require('../lib/near2eth-relay')
 
 class DangerSubmitInvalidNearBlock {

--- a/environment/commands/init-eth-contracts.js
+++ b/environment/commands/init-eth-contracts.js
@@ -68,8 +68,8 @@ class InitEthEd25519 {
       5000000
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
-      throw 1
+      console.log('Can\'t deploy', contractName)
+      process.exit(1)
     }
   }
 }
@@ -84,8 +84,8 @@ class InitEthErc20 {
       3000000
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
-      throw 1
+      console.log('Can\'t deploy', contractName)
+      process.exit(1)
     }
   }
 }
@@ -104,8 +104,8 @@ class InitEthLocker {
       3000000
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
-      throw 1
+      console.log('Can\'t deploy', contractName)
+      process.exit(1)
     }
   }
 }
@@ -135,8 +135,8 @@ class InitEthClient {
       3000000
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
-      throw 1
+      console.log('Can\'t deploy', contractName)
+      process.exit(1)
     }
   }
 }
@@ -151,8 +151,8 @@ class InitEthProver {
       3000000
     )
     if (!success) {
-      console.log("Can't deploy", contractName)
-      throw 1
+      console.log('Can\'t deploy', contractName)
+      process.exit(1)
     }
   }
 }

--- a/environment/commands/init-near-contracts.js
+++ b/environment/commands/init-near-contracts.js
@@ -1,4 +1,3 @@
-const Web3 = require('web3')
 const nearlib = require('near-api-js')
 const { maybeCreateAccount, verifyAccount } = require('../lib/near-helpers')
 const { NearClientContract } = require('../lib/near-client-contract')

--- a/environment/commands/near-dump.js
+++ b/environment/commands/near-dump.js
@@ -21,7 +21,7 @@ async function getLatestBlock(nearNodeUrl) {
 }
 
 async function getBlockChunk(nearNodeUrl, block) {
-  let resp = await fetch(nearNodeUrl, {
+  const resp = await fetch(nearNodeUrl, {
     method: 'post',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -31,33 +31,33 @@ async function getBlockChunk(nearNodeUrl, block) {
       params: [block.chunks[0].chunk_hash],
     }),
   })
-  let data = await resp.json()
+  const data = await resp.json()
   return data.result
 }
 
-async function getTxProof(nearNodeUrl, futureBlock, txn) {
-  let resp = await fetch(nearNodeUrl, {
-    method: 'post',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 'dontcare',
-      method: 'light_client_proof',
-      params: {
-        type: 'transaction',
-        transaction_hash: txn.hash,
-        receiver_id: txn.receiver_id,
-        sender_id: txn.signer_id,
-        light_client_head: futureBlock.header.hash,
-      },
-    }),
-  })
-  let data = await resp.json()
-  return data.result
-}
+// async function getTxProof(nearNodeUrl, futureBlock, txn) {
+//   const resp = await fetch(nearNodeUrl, {
+//     method: 'post',
+//     headers: { 'Content-Type': 'application/json' },
+//     body: JSON.stringify({
+//       jsonrpc: '2.0',
+//       id: 'dontcare',
+//       method: 'light_client_proof',
+//       params: {
+//         type: 'transaction',
+//         transaction_hash: txn.hash,
+//         receiver_id: txn.receiver_id,
+//         sender_id: txn.signer_id,
+//         light_client_head: futureBlock.header.hash,
+//       },
+//     }),
+//   })
+//   const data = await resp.json()
+//   return data.result
+// }
 
 async function getReceiptProof(nearNodeUrl, futureBlock, receipt) {
-  let resp = await fetch(nearNodeUrl, {
+  const resp = await fetch(nearNodeUrl, {
     method: 'post',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -72,7 +72,7 @@ async function getReceiptProof(nearNodeUrl, futureBlock, receipt) {
       },
     }),
   })
-  let data = await resp.json()
+  const data = await resp.json()
   return data.result
 }
 
@@ -105,11 +105,11 @@ class NearDump {
     }
     const nearNodeUrl = RainbowConfig.getParam('near-node-url')
 
-    let latestBlock = await getLatestBlock(nearNodeUrl)
+    const latestBlock = await getLatestBlock(nearNodeUrl)
 
-    if (kindOfData == 'headers') {
+    if (kindOfData === 'headers') {
       await NearDump.dumpHeaders(nearNodeUrl, path, latestBlock, numBlocks)
-    } else if (kindOfData == 'proofs') {
+    } else if (kindOfData === 'proofs') {
       await NearDump.dumpProofs(nearNodeUrl, path, latestBlock, numBlocks)
     }
   }
@@ -153,19 +153,19 @@ class NearDump {
       newLatestBlock = await getLatestBlock(nearNodeUrl)
       if (newLatestBlock.header.height > latestBlock.header.height) {
         console.log(`Got new block at height ${newLatestBlock.header.height}`)
-        let chunk = await getBlockChunk(nearNodeUrl, latestBlock)
+        const chunk = await getBlockChunk(nearNodeUrl, latestBlock)
         console.log(
           `There are ${chunk.transactions.length} txns in block ${latestBlock.header.height}'s chunk`
         )
         console.log(
           `There are ${chunk.receipts.length} receipts in block  ${latestBlock.header.height}'s chunk`
         )
-        for (let i in chunk.transactions) {
-          //let proof = await getTxProof(nearNodeUrl, newLatestBlock, chunk.transactions[i]);
-          //await NearDump.saveProof(latestBlock.header.height, 'txn', i, proof, path)
-        }
-        for (let i in chunk.receipts) {
-          let proof = await getReceiptProof(
+        // for (const i in chunk.transactions) {
+        //   let proof = await getTxProof(nearNodeUrl, newLatestBlock, chunk.transactions[i]);
+        //   await NearDump.saveProof(latestBlock.header.height, 'txn', i, proof, path)
+        // }
+        for (const i in chunk.receipts) {
+          const proof = await getReceiptProof(
             nearNodeUrl,
             newLatestBlock,
             chunk.receipts[i]

--- a/environment/commands/status.js
+++ b/environment/commands/status.js
@@ -35,7 +35,7 @@ const request = async url => {
     return [
       Ok,
       JSON.stringify(json.version),
-      JSON.stringify(json.sync_info['latest_block_height']),
+      JSON.stringify(json.sync_info.latest_block_height),
     ]
   } catch (err) {
     return [Error, Unreachable, Unknown]
@@ -79,9 +79,9 @@ class NearContracts {
       return new Status(Unknown, Error, ContractNotFound)
     }
     try {
-      const contract = new nearlib.Contract(masterAccount, contractAccount, {})
+      // const contract = new nearlib.Contract(masterAccount, contractAccount, {})
       // TODO #257 check contract validity here
-      //console.log(contract);
+      // console.log(contract);
       return new Status(Unknown, Info, NotVerified)
     } catch (err) {
       return new Status(Unknown, Error, InternalError)
@@ -235,7 +235,7 @@ class EthContracts {
     try {
       const abi = JSON.parse(fs.readFileSync(abiPath))
       const contract = await new web3.eth.Contract(abi, address)
-      if (contract.options.address == address) {
+      if (contract.options.address === address) {
         // TODO #257 check deployed code equality if possible
         return new Status(contract.options.address, Ok, Deployed)
       } else {
@@ -323,18 +323,18 @@ function printLine(field, status = null) {
   }
   var color = '\x1B[35m'
   switch (status.verdict) {
-    case Ok:
-      var color = '\x1B[32m'
-      break
-    case Info:
-      var color = '\x1B[39m'
-      break
-    case Warn:
-      var color = '\x1B[33m'
-      break
-    case Error:
-      var color = '\x1B[35m'
-      break
+  case Ok:
+    color = '\x1B[32m'
+    break
+  case Info:
+    color = '\x1B[39m'
+    break
+  case Warn:
+    color = '\x1B[33m'
+    break
+  case Error:
+    color = '\x1B[35m'
+    break
   }
   const explanation = status.explanation ? '(' + status.explanation + ')' : ''
   var line = field + ':'

--- a/environment/commands/transfer-eth-erc20-from-near.js
+++ b/environment/commands/transfer-eth-erc20-from-near.js
@@ -1,4 +1,3 @@
-const Web3 = require('web3')
 const nearlib = require('near-api-js')
 const BN = require('bn.js')
 const fs = require('fs')
@@ -94,7 +93,7 @@ class TransferEthERC20FromNear {
         if (receipts.length === 1) {
           txReceiptId = receipts[0]
           txReceiptBlockHash = txBurn.receipts_outcome.find(
-            el => el.id == txReceiptId
+            el => el.id === txReceiptId
           ).block_hash
           idType = 'receipt'
         } else {
@@ -121,7 +120,7 @@ class TransferEthERC20FromNear {
     const outcomeBlockHeight = new BN(outcomeBlock.header.height)
 
     // Wait for the block with the given receipt/transaction in Near2EthClient.
-    let robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
+    const robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
     const web3 = robustWeb3.web3
     let ethMasterAccount = web3.eth.accounts.privateKeyToAccount(
       normalizeEthKey(RainbowConfig.getParam('eth-master-sk'))

--- a/environment/commands/transfer-eth-erc20-to-near.js
+++ b/environment/commands/transfer-eth-erc20-to-near.js
@@ -1,6 +1,5 @@
 const utils = require('ethereumjs-util')
 const BN = require('bn.js')
-const Web3 = require('web3')
 const fs = require('fs')
 const nearlib = require('near-api-js')
 const {
@@ -98,7 +97,7 @@ class TransferETHERC20ToNear {
 
     let logFound = false
     let log
-    for (let receiptLog of receipt.logs) {
+    for (const receiptLog of receipt.logs) {
       txLogIndex++
       const blockLogIndex = receiptLog.logIndex
       if (blockLogIndex === lockedEvent.logIndex) {
@@ -226,7 +225,7 @@ class TransferETHERC20ToNear {
   }
 
   static parseBuffer(obj) {
-    for (let i in obj) {
+    for (const i in obj) {
       if (obj[i] && obj[i].type === 'Buffer') {
         obj[i] = Buffer.from(obj[i].data)
       } else if (obj[i] && typeof obj[i] === 'object') {
@@ -238,7 +237,7 @@ class TransferETHERC20ToNear {
 
   static loadTransferLog() {
     try {
-      let log =
+      const log =
         JSON.parse(
           fs.readFileSync('transfer-eth-erc20-to-near.log.json').toString()
         ) || {}
@@ -264,8 +263,8 @@ class TransferETHERC20ToNear {
     const nearReceiverAccount = command.nearReceiverAccount
 
     // @ts-ignore
-    let robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
-    let web3 = robustWeb3.web3
+    const robustWeb3 = new RobustWeb3(RainbowConfig.getParam('eth-node-url'))
+    const web3 = robustWeb3.web3
     let ethSenderAccount = web3.eth.accounts.privateKeyToAccount(
       normalizeEthKey(ethSenderSk)
     )

--- a/environment/lib/borsh/index.js
+++ b/environment/lib/borsh/index.js
@@ -216,7 +216,7 @@ const signAndSendTransactionAsync = async (
   actions
 ) => {
   const status = await account.connection.provider.status()
-  let [txHash, signedTx] = await nearlib.transactions.signTransaction(
+  const [txHash, signedTx] = await nearlib.transactions.signTransaction(
     receiverId,
     ++accessKey.nonce,
     actions,
@@ -267,7 +267,7 @@ const txnStatus = async (
     result.transaction_outcome,
     ...result.receipts_outcome,
   ].reduce((acc, it) => acc.concat(it.outcome.logs), [])
-  if (flatLogs && flatLogs != []) {
+  if (flatLogs && flatLogs !== []) {
     console.log(flatLogs)
   }
 
@@ -348,7 +348,7 @@ const signAndSendTransaction = async (
         result.transaction_outcome,
         ...result.receipts_outcome,
       ].reduce((acc, it) => acc.concat(it.outcome.logs), [])
-      if (flatLogs && flatLogs != []) {
+      if (flatLogs && flatLogs.length) {
         console.log(flatLogs)
       }
 
@@ -520,12 +520,12 @@ function borshify(block) {
         signature === null
           ? Buffer.from([0])
           : Buffer.concat([
-              Buffer.from([1]),
-              signature.substr(0, 8) === 'ed25519:'
-                ? Buffer.from([0])
-                : Buffer.from([1]),
-              bs58.decode(signature.substr(8)),
-            ])
+            Buffer.from([1]),
+            signature.substr(0, 8) === 'ed25519:'
+              ? Buffer.from([0])
+              : Buffer.from([1]),
+            bs58.decode(signature.substr(8)),
+          ])
       )
     ),
   ])

--- a/environment/lib/eth-proof-extractor/index.js
+++ b/environment/lib/eth-proof-extractor/index.js
@@ -1,8 +1,6 @@
-const Web3 = require('web3')
 const Tree = require('merkle-patricia-tree')
-const utils = require('ethereumjs-util')
 const { Header, Proof, Receipt, Log } = require('eth-object')
-const { encode, toBuffer } = require('eth-util-lite')
+const { encode } = require('eth-util-lite')
 const { promisfy } = require('promisfy')
 const { RobustWeb3 } = require('../robust')
 

--- a/environment/lib/eth2near-relay.js
+++ b/environment/lib/eth2near-relay.js
@@ -1,4 +1,3 @@
-const Web3 = require('web3')
 const exec = require('child_process').exec
 const utils = require('ethereumjs-util')
 const BN = require('bn.js')
@@ -82,7 +81,7 @@ class Eth2NearRelay {
       if (clientBlockNumber < chainBlockNumber) {
         try {
           // Submit add_block txns
-          let blockPromises = []
+          const blockPromises = []
           let endBlock = Math.min(
             clientBlockNumber + MAX_SUBMIT_BLOCK,
             chainBlockNumber
@@ -94,12 +93,12 @@ class Eth2NearRelay {
           for (let i = clientBlockNumber + 1; i <= endBlock; i++) {
             blockPromises.push(this.getParseBlock(i))
           }
-          let blocks = await Promise.all(blockPromises)
+          const blocks = await Promise.all(blockPromises)
           console.log(
             `Got and parsed block ${clientBlockNumber + 1} to block ${endBlock}`
           )
 
-          let txHashes = []
+          const txHashes = []
           for (let i = clientBlockNumber + 1, j = 0; i <= endBlock; i++, j++) {
             txHashes.push(await this.submitBlock(blocks[j], i))
           }

--- a/environment/lib/near-client-contract/index.js
+++ b/environment/lib/near-client-contract/index.js
@@ -3,7 +3,6 @@ const { web3BlockToRlp } = require('../eth2near-relay')
 const Web3 = require('web3')
 const BN = require('bn.js')
 const { BorshContract, hexToBuffer, readerToHex } = require('../borsh')
-const { RobustWeb3 } = require('../robust')
 // @ts-ignore
 const roots = require('./dag_merkle_roots.json')
 

--- a/environment/lib/near2eth-relay.js
+++ b/environment/lib/near2eth-relay.js
@@ -1,4 +1,3 @@
-const Web3 = require('web3')
 const nearlib = require('near-api-js')
 const fs = require('fs')
 // @ts-ignore
@@ -86,12 +85,12 @@ class Near2EthRelay {
           // Because fetch currentValidators and lightClientBlock isn't atomic, it's possible we happen to
           // fetch lightClentBlock cross epoch boundary. Fetch another time to ensure that's not the case.
           // @ts-ignore
-          let currentValidatorsNow = await this.near.connection.provider.validators(
+          const currentValidatorsNow = await this.near.connection.provider.validators(
             null
           )
           if (
             !currentValidatorsNow ||
-            currentValidatorsNow.epoch_start_height !=
+            currentValidatorsNow.epoch_start_height !==
               currentValidators.epoch_start_height
           ) {
             await sleep(300)
@@ -253,7 +252,7 @@ class Near2EthRelay {
     }
     console.log(`${JSON.stringify(lightClientBlock)}`)
     while (true) {
-      let borshBlock = borshify(lightClientBlock)
+      const borshBlock = borshify(lightClientBlock)
       console.log('Mutate block by one byte')
       console.log(borshBlock)
       borshBlock[Math.floor(borshBlock.length * Math.random())] += 1
@@ -399,7 +398,7 @@ class Near2EthRelay {
         }
       }
 
-      let sleepTime = new BN(
+      const sleepTime = new BN(
         RainbowConfig.getParam('near2eth-relay-delay')
       ).toNumber()
       if (sleepTime > 0) {

--- a/environment/lib/near2eth-watchdog.js
+++ b/environment/lib/near2eth-watchdog.js
@@ -1,5 +1,4 @@
 const Web3 = require('web3')
-const BN = require('bn.js')
 const fs = require('fs')
 const { RainbowConfig } = require('./config')
 const {
@@ -68,7 +67,7 @@ class Near2EthWatchdog {
           console.log(`Challenging signature ${i}.`)
           try {
             let gasPrice = await this.web3.eth.getGasPrice()
-            let nonce = await this.web3.eth.getTransactionCount(
+            const nonce = await this.web3.eth.getTransactionCount(
               this.ethMasterAccount
             )
             while (gasPrice < 10000 * 1e9) {

--- a/environment/lib/robust.js
+++ b/environment/lib/robust.js
@@ -11,11 +11,11 @@ const retry = (retries, fn) =>
   fn().catch(err =>
     retries > 1 ? retry(retries - 1, fn) : Promise.reject(err)
   )
-const sleep = duration => new Promise(res => setTimeout(res, duration))
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration))
 const backoff = (retries, fn, delay = DELAY, wait = BACKOFF) =>
   fn().catch(err =>
     retries > 1
-      ? sleep(delay).then(() => backoff(retries - 1, fn, delay * wait))
+      ? sleep(delay).then(() => backoff(retries - 1, fn, delay * wait)) // eslint-disable-line promise/no-nesting
       : Promise.reject(err)
   )
 
@@ -57,7 +57,7 @@ class RobustWeb3 {
     while (gasPrice < 10000 * 1e9) {
       try {
         // Keep sending with same nonce but higher gasPrice to override same txn
-        let tx = {
+        const tx = {
           from: options.from,
           to: contract.options.address,
           gas: Web3.utils.toHex(options.gas),
@@ -66,7 +66,7 @@ class RobustWeb3 {
           data: contract.methods[method](...args).encodeABI(),
         }
 
-        let receipt = await promiseWithTimeout(
+        const receipt = await promiseWithTimeout(
           5 * 60 * 1000,
           this.web3.eth.sendTransaction(tx),
           SLOW_TX_ERROR_MSG
@@ -114,7 +114,7 @@ class RobustWeb3 {
           )
           gasPrice *= 2
         } else if (
-          e.message.indexOf("the tx doesn't have the correct nonce") >= 0
+          e.message.indexOf('the tx doesn\'t have the correct nonce') >= 0
         ) {
           console.log('nonce error, retrying with new nonce')
           nonce++


### PR DESCRIPTION
environment/.eslintrc defined many settings, but some of these weren't
being used at all and other standards were being used in the code
(example: lint settings required semicolons, but no code used them)

this updates settings to match the code for several rules, and updates
the code to match the settings for the others

before merge:

- [ ] add lint step to CI