### PR TITLE
options to init contract with trusted signer

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ RainbowConfig.declareOption('eth-node-url', 'The URL of the Ethereum node.')
 RainbowConfig.declareOption(
   'near-master-account',
   'The account of the master account on NEAR blockchain that can be used to deploy and initialize the test contracts.' +
-    ' This account will also own the initial supply of the fungible tokens.'
+  ' This account will also own the initial supply of the fungible tokens.'
 )
 RainbowConfig.declareOption(
   'near-master-sk',
@@ -87,8 +87,13 @@ RainbowConfig.declareOption(
 )
 RainbowConfig.declareOption(
   'near-client-validate-ethash',
-  'The initial balance of Near Client contract in femtoNEAR.',
+  'Whether validate ethash of submitted eth block, should set to true on mainnet and false on PoA testnets',
   'true'
+)
+RainbowConfig.declareOption(
+  'near-client-trusted-signer',
+  'When non empty, deploy as trusted-signer mode where only tursted signer can submit blocks to client',
+  ''
 )
 RainbowConfig.declareOption(
   'near-prover-account',
@@ -328,6 +333,7 @@ RainbowConfig.addOptions(
     'near-client-contract-path',
     'near-client-init-balance',
     'near-client-validate-ethash',
+    'near-client-trusted-signer',
     'near-prover-account',
     'near-prover-sk',
     'near-prover-contract-path',
@@ -551,6 +557,6 @@ RainbowConfig.addOptions(
     .action(NearDump.execute),
   ['near-node-url']
 )
-;(async () => {
-  await program.parseAsync(process.argv)
-})()
+  ; (async () => {
+    await program.parseAsync(process.argv)
+  })()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rainbow-bridge-cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "CLI to set up the environment needed for the bridge to work.",
   "main": "index.js",
   "bin": {
@@ -30,9 +30,9 @@
     "node-fetch": "^2.6.0",
     "pm2": "^4.4.0",
     "pm2-promise": "^2.0.1",
-    "rainbow-bridge-lib": "^1.0.0",
-    "rainbow-bridge-rs": "^1.0.0",
-    "rainbow-bridge-sol": "^1.0.10",
+    "rainbow-bridge-lib": "1.0.2",
+    "rainbow-bridge-rs": "1.0.2",
+    "rainbow-bridge-sol": "1.0.11",
     "request": "^2.88.2",
     "web3": "=1.2.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4027,10 +4027,10 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-rainbow-bridge-lib@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rainbow-bridge-lib/-/rainbow-bridge-lib-1.0.0.tgz#d798957817917a44295db1198e2fcadb8619213f"
-  integrity sha512-A3wQSpMQMXXz+mwHXnsT/UCstsYPJgyFDittPd9bodz30vTbL8/Wq8WMdBg1pnp9ZQ71mbrTN2exxqs4dwWL6Q==
+rainbow-bridge-lib@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rainbow-bridge-lib/-/rainbow-bridge-lib-1.0.2.tgz#9e8fea884d5266f8f0c120a2c022c1a89af43e00"
+  integrity sha512-w3zuZbREGEC753Y/u7tPbnFMynPlXgYTHV1iTuRiL8CqNHpCeKSkcxWjUaYdgCd+FovpgbbyoRT4rw+1RH9CYQ==
   dependencies:
     bn.js "^5.1.3"
     bs58 "^4.0.1"
@@ -4048,15 +4048,15 @@ rainbow-bridge-lib@^1.0.0:
     promisfy "^1.2.0"
     web3 "=1.2.6"
 
-rainbow-bridge-rs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rainbow-bridge-rs/-/rainbow-bridge-rs-1.0.0.tgz#34294969bf3de1225a0dca703de7ff4daa58bcb8"
-  integrity sha512-HiX7YdxAZRxaxFsXJQKJc/h9KWWhgZOmP3GQlFxL/eyEV1krU5NqOyZOqBNUB1MPIh3qtiZEXsovsbLDzBm6Nw==
+rainbow-bridge-rs@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rainbow-bridge-rs/-/rainbow-bridge-rs-1.0.2.tgz#824a9f3cb00f083cbf737d5dc7bc11b0682de27c"
+  integrity sha512-8HHPwsDmTIvROzJPvbw6RJDKnge8xDAi9MBdCVuC1JdU51t6aFRHZBsORvdGd89yYQaz3hLm8jWzTZtYV2XOdA==
 
-rainbow-bridge-sol@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/rainbow-bridge-sol/-/rainbow-bridge-sol-1.0.10.tgz#3cf1f45068d53e04490517d38667c53a740e13fe"
-  integrity sha512-JVuPB1oe43piVew0VIDZp1q3nm/Dz/i91FZzj0Cqc7pC3Ko5YlYMGRIrRcgPRCDyDD/m0OPDsIBhavQ54efoyg==
+rainbow-bridge-sol@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/rainbow-bridge-sol/-/rainbow-bridge-sol-1.0.11.tgz#67654455ae17f6604f314eed2d6e77edf8da9b41"
+  integrity sha512-31TBeg1b16/Y/s64B89AW1uCiqkOgT64p9/2T6MKlcOJ46ky2qHhntfKpgU9Ymjsg0aYeDZzIbeZ+hY3qCHJ+Q==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Now you can init eth-client near contract with trusted-signer, default to ''. Locally i tested:
- init without trusted-signer, e2e tests behave as before
- init with `node index.js init-near-contracts --near-client-trusted-signer node0`, it can successfully submit blocks
- init with `node index.js init-near-contracts --near-client-trusted-signer someone-else`, submit blocks are rejected with error:
```
Error: {"ActionError":{"index":0,"kind":{"FunctionCallError":{"HostError":{"GuestPanic":{"panic_msg":"panicked at 'Eth-client is deployed as trust mode, only trusted_signer can add a new header', eth-client/src/lib.rs:210:13"}}}}}}
```

Note, to test locally, need to use https://github.com/near/rainbow-bridge-rs/pull/7 and https://github.com/near/rainbow-bridge-lib/pull/6 in rainbow-bridge-cli/node_modules. A quick way to redeploy updated contracts to near is:
```
node index.js stop near-node
rm -rf ~/.near/localnet/node0/data
node index.js start near-node
node index.js init-near-contracts --near-client-trusted-signer node0 # or without, or with a different trusted signer
node index.js start eth2near-relay --daemon false
```

This must be merge after 
https://github.com/near/rainbow-bridge-rs/pull/7
https://github.com/near/rainbow-bridge-lib/pull/6