### PR TITLE
fix: rainbow --version should return the version package

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ RainbowConfig.declareOption(
 )
 RainbowConfig.declareOption('near-erc20-account', 'Must be declared before set')
 
-program.version('0.1.0')
+program.version(require('./package.json').version)
 
 // General-purpose commands.
 program.command('clean').action(CleanCommand.execute)


### PR DESCRIPTION
*Resolves #365*

This is [the officially suggested solution](https://github.com/tj/commander.js/issues/48#issuecomment-49087390). I manually checked that this works for:

* global installation: `npm install -g git+https://github.com/near/rainbow-bridge-cli.git#18b9028311463396ebb5d1a8b26d8f434fac84d0`

  ```bash
  $ npm install -g git+https://github.com/near/rainbow-bridge-cli.git#18b9028311463396ebb5d1a8b26d8f434fac84d0
  $ rainbow --version
  3.0.0
  ```
* local installation:

  ```bash
  $ npm install git+https://github.com/near/rainbow-bridge-cli.git#18b9028311463396ebb5d1a8b26d8f434fac84d0
  $ ./node_modules/.bin/rainbow --version
  3.0.0
  ```
* local development:

  ```bash
  $ git clone ... && cd rainbow-bridge-cli
  $ npm install
  $ node -- index.js --version
  3.0.0
  ```