### PR TITLE
Pin nearup to use old v1 nearup release 0.1.2

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -48,6 +48,7 @@ echo "Linking the specified local repo from ${LOCAL_NEARUP_SRC} to ${NEARUP_SRC}
 ln -s $LOCAL_NEARUP_SRC $NEARUP_SRC
 fi
 mkdir -p $NEARUP_LOGS
+cd $NEARUP_SRC && git checkout 0.1.2
 
 cd $CORE_SRC
 cargo build --package neard --bin neard


### PR DESCRIPTION
Pin the nearup version to the 0.1.2 release which is nearup v1, so we can land nearup v2 onto master.  Create a release for nearup v1: https://github.com/near/nearup/releases/tag/0.1.2 and latest version of nearup v2 which should be installed via pip once @mhalambek finishes his PR, this is just for now.